### PR TITLE
Ensure boolean for preAuthorizationRequired in GQL

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -108,7 +108,7 @@ export function formatMedicalItemOrServiceGQL(mm, ms) {
     ${ms.package ? `package: "${formatGQLString(ms.package)}"` : ""}
     ${ms.packagetype ? `packagetype: "${formatGQLString(ms.packagetype)}"` : ""}
     ${ms.packagetype ?`manualPrice: "${formatGQLBoolean(ms.manualPrice)}"` : "" }
-    ${ms.preAuthorizationRequired ? `preAuthorizationRequired: ${ms.preAuthorizationRequired}` : ""}
+    ${ `preAuthorizationRequired: ${!!ms.preAuthorizationRequired}` }
     ${formatDetails("service", ms.serviceserviceSet)}
     ${formatDetails("item", ms.servicesLinked)}
   `;


### PR DESCRIPTION
Updated the formatMedicalItemOrServiceGQL function to always output a boolean value for preAuthorizationRequired, ensuring consistent GraphQL formatting regardless of the input type.